### PR TITLE
make cidr range correct

### DIFF
--- a/ip/cidr/cidr.go
+++ b/ip/cidr/cidr.go
@@ -52,7 +52,7 @@ func main() {
 	fmt.Println("------------------------------------------------")
 	fmt.Printf("CIDR Block:     %s\n", cidr)
 	fmt.Printf("Network:        %s\n", ipnet.IP)
-	fmt.Printf("IP Range:       %s - %s\n", ip, last)
+	fmt.Printf("IP Range:       %s - %s\n", ipnet.IP, last)
 	fmt.Printf("Total Hosts:    %0.0f\n", totalHosts)
 	fmt.Printf("Netmask:        %s\n", net.IP(ipnet.Mask))
 	fmt.Printf("Wildcard Mask:  %s\n", wildcardIP)


### PR DESCRIPTION
in cidr.go example the range start ip was cidr input ip which is not correct and must be be network ip and i tried to make it correct. It would be my pleasure if you review this change and if it is correct accept the pull request. 